### PR TITLE
Rename variables to begin with lowercase.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ However, that'll only work if the arguments are constant and known in advance. O
 // fetchRepoDescription fetches description of repo with owner and name.
 func fetchRepoDescription(ctx context.Context, owner, name string) (string, error) {
 	variables := map[string]interface{}{
-		"Owner": githubql.String(owner),
-		"Name":  githubql.String(name),
+		"owner": githubql.String(owner),
+		"name":  githubql.String(name),
 	}
 ```
 
@@ -179,7 +179,7 @@ Then, replace the constants in the struct field tag with variable names:
 	var q struct {
 		Repository struct {
 			Description githubql.String
-		} `graphql:"repository(owner: $Owner, name: $Name)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 ```
 
@@ -213,15 +213,15 @@ var q struct {
 					EndCursor   githubql.String
 					HasNextPage githubql.Boolean
 				}
-			} `graphql:"comments(first: 100, after: $CommentsCursor)"` // 100 per page.
-		} `graphql:"issue(number: $IssueNumber)"`
-	} `graphql:"repository(owner: $RepositoryOwner, name: $RepositoryName)"`
+			} `graphql:"comments(first: 100, after: $commentsCursor)"` // 100 per page.
+		} `graphql:"issue(number: $issueNumber)"`
+	} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
 }
 variables := map[string]interface{}{
-	"RepositoryOwner": githubql.String(owner),
-	"RepositoryName":  githubql.String(name),
-	"IssueNumber":     githubql.Int(issue),
-	"CommentsCursor":  (*githubql.String)(nil), // Null after argument to get first page.
+	"repositoryOwner": githubql.String(owner),
+	"repositoryName":  githubql.String(name),
+	"issueNumber":     githubql.Int(issue),
+	"commentsCursor":  (*githubql.String)(nil), // Null after argument to get first page.
 }
 
 // Get comments from all pages.
@@ -235,7 +235,7 @@ for {
 	if !q.Repository.Issue.Comments.PageInfo.HasNextPage {
 		break
 	}
-	variables["CommentsCursor"] = githubql.NewString(q.Repository.Issue.Comments.PageInfo.EndCursor)
+	variables["commentsCursor"] = githubql.NewString(q.Repository.Issue.Comments.PageInfo.EndCursor)
 }
 ```
 
@@ -248,8 +248,8 @@ Mutations often require information that you can only find out by performing a q
 For example, to make the following GraphQL mutation:
 
 ```GraphQL
-mutation($Input: AddReactionInput!) {
-	addReaction(input: $Input) {
+mutation($input: AddReactionInput!) {
+	addReaction(input: $input) {
 		reaction {
 			content
 		}
@@ -259,7 +259,7 @@ mutation($Input: AddReactionInput!) {
 	}
 }
 variables {
-	"Input": {
+	"input": {
 		"subjectId": "MDU6SXNzdWUyMTc5NTQ0OTc=",
 		"content": "HOORAY"
 	}
@@ -277,7 +277,7 @@ var m struct {
 		Subject struct {
 			ID githubql.ID
 		}
-	} `graphql:"addReaction(input: $Input)"`
+	} `graphql:"addReaction(input: $input)"`
 }
 input := githubql.AddReactionInput{
 	SubjectID: targetIssue.ID, // ID of the target issue from a previous query.

--- a/example/githubqldev/main.go
+++ b/example/githubqldev/main.go
@@ -79,9 +79,9 @@ func run() error {
 							EndCursor   githubql.String
 							HasNextPage githubql.Boolean
 						}
-					} `graphql:"comments(first:$CommentsFirst,after:$CommentsAfter)"`
-				} `graphql:"issue(number:$IssueNumber)"`
-			} `graphql:"repository(owner:$RepositoryOwner,name:$RepositoryName)"`
+					} `graphql:"comments(first:$commentsFirst,after:$commentsAfter)"`
+				} `graphql:"issue(number:$issueNumber)"`
+			} `graphql:"repository(owner:$repositoryOwner,name:$repositoryName)"`
 			Viewer struct {
 				Login      githubql.String
 				CreatedAt  githubql.DateTime
@@ -96,11 +96,11 @@ func run() error {
 			}
 		}
 		variables := map[string]interface{}{
-			"RepositoryOwner": githubql.String("shurcooL-test"),
-			"RepositoryName":  githubql.String("test-repo"),
-			"IssueNumber":     githubql.Int(1),
-			"CommentsFirst":   githubql.NewInt(1),
-			"CommentsAfter":   githubql.NewString("Y3Vyc29yOjE5NTE4NDI1Ng=="),
+			"repositoryOwner": githubql.String("shurcooL-test"),
+			"repositoryName":  githubql.String("test-repo"),
+			"issueNumber":     githubql.Int(1),
+			"commentsFirst":   githubql.NewInt(1),
+			"commentsAfter":   githubql.NewString("Y3Vyc29yOjE5NTE4NDI1Ng=="),
 		}
 		err := client.Query(context.Background(), &q, variables)
 		if err != nil {
@@ -122,15 +122,15 @@ func run() error {
 					ID        githubql.ID
 					Reactions struct {
 						ViewerHasReacted githubql.Boolean
-					} `graphql:"reactions(content:$ReactionContent)"`
-				} `graphql:"issue(number:$IssueNumber)"`
-			} `graphql:"repository(owner:$RepositoryOwner,name:$RepositoryName)"`
+					} `graphql:"reactions(content:$reactionContent)"`
+				} `graphql:"issue(number:$issueNumber)"`
+			} `graphql:"repository(owner:$repositoryOwner,name:$repositoryName)"`
 		}
 		variables := map[string]interface{}{
-			"RepositoryOwner": githubql.String("shurcooL-test"),
-			"RepositoryName":  githubql.String("test-repo"),
-			"IssueNumber":     githubql.Int(2),
-			"ReactionContent": githubql.ThumbsUp,
+			"repositoryOwner": githubql.String("shurcooL-test"),
+			"repositoryName":  githubql.String("test-repo"),
+			"issueNumber":     githubql.Int(2),
+			"reactionContent": githubql.ThumbsUp,
 		}
 		err := client.Query(context.Background(), &q, variables)
 		if err != nil {
@@ -150,7 +150,7 @@ func run() error {
 							}
 						}
 					}
-				} `graphql:"addReaction(input:$Input)"`
+				} `graphql:"addReaction(input:$input)"`
 			}
 			input := githubql.AddReactionInput{
 				SubjectID: q.Repository.Issue.ID,
@@ -174,7 +174,7 @@ func run() error {
 							}
 						}
 					}
-				} `graphql:"removeReaction(input:$Input)"`
+				} `graphql:"removeReaction(input:$input)"`
 			}
 			input := githubql.RemoveReactionInput{
 				SubjectID: q.Repository.Issue.ID,

--- a/githubql.go
+++ b/githubql.go
@@ -39,12 +39,12 @@ func (c *Client) Query(ctx context.Context, q interface{}, variables map[string]
 // Mutate executes a single GraphQL mutation request,
 // with a mutation derived from m, populating the response into it.
 // m should be a pointer to struct that corresponds to the GitHub GraphQL schema.
-// Provided input will be set as a variable named "Input".
+// Provided input will be set as a variable named "input".
 func (c *Client) Mutate(ctx context.Context, m interface{}, input Input, variables map[string]interface{}) error {
 	if variables == nil {
-		variables = map[string]interface{}{"Input": input}
+		variables = map[string]interface{}{"input": input}
 	} else {
-		variables["Input"] = input
+		variables["input"] = input
 	}
 	return c.do(ctx, mutationOperation, m, variables)
 }

--- a/githubql_test.go
+++ b/githubql_test.go
@@ -112,7 +112,7 @@ func TestClient_Mutate(t *testing.T) {
 			t.Errorf("got request method: %v, want: %v", got, want)
 		}
 		body := mustRead(req.Body)
-		if got, want := body, `{"query":"mutation($Input:AddReactionInput!){addReaction(input:$Input){reaction{content},subject{id,reactionGroups{users{totalCount}}}}}","variables":{"Input":{"subjectId":"MDU6SXNzdWUyMTc5NTQ0OTc=","content":"HOORAY"}}}`+"\n"; got != want {
+		if got, want := body, `{"query":"mutation($input:AddReactionInput!){addReaction(input:$input){reaction{content},subject{id,reactionGroups{users{totalCount}}}}}","variables":{"input":{"subjectId":"MDU6SXNzdWUyMTc5NTQ0OTc=","content":"HOORAY"}}}`+"\n"; got != want {
 			t.Errorf("got body: %v, want %v", got, want)
 		}
 		mustWrite(w, `{"data": {
@@ -147,7 +147,7 @@ func TestClient_Mutate(t *testing.T) {
 				ID             githubql.ID
 				ReactionGroups []reactionGroup
 			}
-		} `graphql:"addReaction(input:$Input)"`
+		} `graphql:"addReaction(input:$input)"`
 	}
 
 	var m mutation

--- a/hacky.go
+++ b/hacky.go
@@ -34,7 +34,7 @@ func constructMutation(v interface{}, variables map[string]interface{}) string {
 
 // queryArguments constructs a minified arguments string for variables.
 //
-// E.g., map[string]interface{}{"A": Int(123), "B": NewBoolean(true)} -> "$A:Int!$B:Boolean".
+// E.g., map[string]interface{}{"a": Int(123), "b": NewBoolean(true)} -> "$a:Int!$b:Boolean".
 func queryArguments(variables map[string]interface{}) string {
 	sorted := make([]string, 0, len(variables))
 	for k := range variables {

--- a/internal_test.go
+++ b/internal_test.go
@@ -153,15 +153,15 @@ func TestConstructQuery(t *testing.T) {
 				Repository struct {
 					Issue struct {
 						Body String
-					} `graphql:"issue(number: $IssueNumber)"`
-				} `graphql:"repository(owner: $RepositoryOwner, name: $RepositoryName)"`
+					} `graphql:"issue(number: $issueNumber)"`
+				} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
 			}{},
 			inVariables: map[string]interface{}{
-				"RepositoryOwner": String("shurcooL-test"),
-				"RepositoryName":  String("test-repo"),
-				"IssueNumber":     Int(1),
+				"repositoryOwner": String("shurcooL-test"),
+				"repositoryName":  String("test-repo"),
+				"issueNumber":     Int(1),
 			},
-			want: `query($IssueNumber:Int!$RepositoryName:String!$RepositoryOwner:String!){repository(owner: $RepositoryOwner, name: $RepositoryName){issue(number: $IssueNumber){body}}}`,
+			want: `query($issueNumber:Int!$repositoryName:String!$repositoryOwner:String!){repository(owner: $repositoryOwner, name: $repositoryName){issue(number: $issueNumber){body}}}`,
 		},
 		{
 			inV: struct {
@@ -174,15 +174,15 @@ func TestConstructQuery(t *testing.T) {
 								}
 							} `graphql:"users(first:10)"`
 						}
-					} `graphql:"issue(number: $IssueNumber)"`
-				} `graphql:"repository(owner: $RepositoryOwner, name: $RepositoryName)"`
+					} `graphql:"issue(number: $issueNumber)"`
+				} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
 			}{},
 			inVariables: map[string]interface{}{
-				"RepositoryOwner": String("shurcooL-test"),
-				"RepositoryName":  String("test-repo"),
-				"IssueNumber":     Int(1),
+				"repositoryOwner": String("shurcooL-test"),
+				"repositoryName":  String("test-repo"),
+				"issueNumber":     Int(1),
 			},
-			want: `query($IssueNumber:Int!$RepositoryName:String!$RepositoryOwner:String!){repository(owner: $RepositoryOwner, name: $RepositoryName){issue(number: $IssueNumber){reactionGroups{users(first:10){nodes{login}}}}}}`,
+			want: `query($issueNumber:Int!$repositoryName:String!$repositoryOwner:String!){repository(owner: $repositoryOwner, name: $repositoryName){issue(number: $issueNumber){reactionGroups{users(first:10){nodes{login}}}}}}`,
 		},
 	}
 	for _, tc := range tests {
@@ -209,15 +209,15 @@ func TestConstructMutation(t *testing.T) {
 							}
 						}
 					}
-				} `graphql:"addReaction(input:$Input)"`
+				} `graphql:"addReaction(input:$input)"`
 			}{},
 			inVariables: map[string]interface{}{
-				"Input": AddReactionInput{
+				"input": AddReactionInput{
 					SubjectID: "MDU6SXNzdWUyMzE1MjcyNzk=",
 					Content:   ThumbsUp,
 				},
 			},
-			want: `mutation($Input:AddReactionInput!){addReaction(input:$Input){subject{reactionGroups{users{totalCount}}}}}`,
+			want: `mutation($input:AddReactionInput!){addReaction(input:$input){subject{reactionGroups{users{totalCount}}}}}`,
 		},
 	}
 	for _, tc := range tests {
@@ -235,8 +235,8 @@ func TestQueryArguments(t *testing.T) {
 		want string
 	}{
 		{
-			in:   map[string]interface{}{"A": Int(123), "B": NewBoolean(true)},
-			want: "$A:Int!$B:Boolean",
+			in:   map[string]interface{}{"a": Int(123), "b": NewBoolean(true)},
+			want: "$a:Int!$b:Boolean",
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
This is more idiomatic GraphQL style. There used to be a technical reason that they had to begin with an uppercase letter before #4, but that's no longer the case.

Since there's no reason to deviate from GraphQL style here, the plan is to follow it more closely for now. That is, until there's a good reason to deviate from it.

This change is really just a documentation/example change. Users can still name variables whatever they want.

Resolves #5.