### PR TITLE
Update for graphql API change.

### DIFF
--- a/githubql.go
+++ b/githubql.go
@@ -19,7 +19,7 @@ type Client struct {
 // the provided http.Client is expected to take care of that.
 func NewClient(httpClient *http.Client) *Client {
 	return &Client{
-		client: graphql.NewClient("https://api.github.com/graphql", httpClient, scalars),
+		client: graphql.NewClient("https://api.github.com/graphql", httpClient),
 	}
 }
 
@@ -31,7 +31,7 @@ func NewClient(httpClient *http.Client) *Client {
 // the provided http.Client is expected to take care of that.
 func NewEnterpriseClient(url string, httpClient *http.Client) *Client {
 	return &Client{
-		client: graphql.NewClient(url, httpClient, scalars),
+		client: graphql.NewClient(url, httpClient),
 	}
 }
 

--- a/scalar.go
+++ b/scalar.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"reflect"
 	"time"
 
 	"github.com/shurcooL/graphql"
@@ -68,14 +67,6 @@ type (
 	// X509Certificate is a valid x509 certificate.
 	X509Certificate struct{ *x509.Certificate }
 )
-
-var scalars = []reflect.Type{
-	reflect.TypeOf(Date{}),
-	reflect.TypeOf(DateTime{}),
-	reflect.TypeOf(GitTimestamp{}),
-	reflect.TypeOf(URI{}),
-	reflect.TypeOf(X509Certificate{}),
-}
 
 // MarshalJSON implements the json.Marshaler interface.
 // The URI is a quoted string.


### PR DESCRIPTION
Follows shurcooL/graphql#4.

(This won't work until that PR is merged.)